### PR TITLE
VOC-9844

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,8 @@ module github.com/Alliera/xlsReader
 
 require (
 	github.com/metakeule/fmtdate v1.1.2
-	golang.org/x/text v0.3.2
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
+	golang.org/x/text v0.3.7
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,10 @@
 github.com/metakeule/fmtdate v1.1.2 h1:n9M7H9HfAqp+6OA98wXGMdcAr6omshSNVct65Bks1lQ=
 github.com/metakeule/fmtdate v1.1.2/go.mod h1:2JyMFlKxeoGy1qS6obQukT0AL0Y4iNANQL8scbSdT4E=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
-golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/helpers/utils.go
+++ b/helpers/utils.go
@@ -3,7 +3,16 @@ package helpers
 import (
 	"bytes"
 	"encoding/binary"
+	"golang.org/x/net/html/charset"
+	"io/ioutil"
+	"strings"
 )
+
+func StrToUtf8(s string) string {
+	r, _ := charset.NewReader(strings.NewReader(s), "")
+	result, _ := ioutil.ReadAll(r)
+	return string(result)
+}
 
 func BytesToUint64(b []byte) uint64 {
 	return binary.LittleEndian.Uint64(b)
@@ -25,7 +34,6 @@ func BytesInSlice(a []byte, list [][]byte) bool {
 	}
 	return false
 }
-
 
 func BytesToUints16(b []byte) (res []uint16) {
 

--- a/xls/structure/XLUnicodeRichExtendedString.go
+++ b/xls/structure/XLUnicodeRichExtendedString.go
@@ -116,15 +116,13 @@ func iOft(offset *uint32, inc uint32) uint32 {
 	return *offset
 }
 
-func (s *XLUnicodeRichExtendedString) String() string {
-
+func (s *XLUnicodeRichExtendedString) String() (str string) {
 	if s.FHighByte&1 == 1 {
 		name := helpers.BytesToUints16(s.Rgb[:])
-		runes := utf16.Decode(name)
-		return string(runes)
+		str = string(utf16.Decode(name))
 	} else {
-
-		return string(s.Rgb[:])
+		str = string(s.Rgb[:])
 	}
-
+	str = helpers.StrToUtf8(str)
+	return
 }


### PR DESCRIPTION
https://sandsiv.atlassian.net/browse/VOC-9844

- Explicitly transform xl cell's unicode-rich-extended string to UTF-8 to avoid unicode symbols' glitches